### PR TITLE
OP-34: Limit number of peers connected to Signaling Server and add rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     },
     "dependencies": {
         "cors": "^2.8.5",
+        "env-cmd": "^10.1.0",
         "express": "^4.17.1",
+        "express-rate-limit": "^7.5.0",
         "sirv": "^1.0.5",
-        "socket.io": "^4.0.1",
-        "socket.io-client": "^4.0.1",
-        "env-cmd": "^10.1.0"
+        "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1"
     },
     "devDependencies": {
         "nodemon": "^2.0.4"

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ app.get("/connections", (req, res) => {
 io.on("connection", (socket) => {
     console.log("User connected with id", socket.id);
 
-    socket.on("ready", (peerId, peerType) => {
+    socket.on("ready", (peerId, peerType, publicKey) => {
         // Make sure that the hostname is unique, if the hostname is already in connections, send an error and disconnect
         if (peerId in connections) {
             socket.emit("uniquenessError", {
@@ -48,14 +48,14 @@ io.on("connection", (socket) => {
             // Let new peer know about all exisiting peers
             socket.send({ from: "all", target: peerId, payload: { action: "open", connections: Object.values(connections), bePolite: false } }); // The new peer doesn't need to be polite.
             // Create new peer
-            const newPeer = { socketId: socket.id, peerId, peerType };
+            const newPeer = { socketId: socket.id, peerId, peerType, publicKey };
             // Updates connections object
             connections[peerId] = newPeer;
             // Let all other peers know about new peer
             socket.broadcast.emit("message", {
                 from: peerId,
                 target: "all",
-                payload: { action: "open", connections: [newPeer], bePolite: true }, // send connections object with an array containing the only new peer and make all exisiting peers polite.
+                payload: { action: "open", connections: connections, bePolite: true }, // send connections object with an array containing the only new peer and make all exisiting peers polite.
             });
         }
     });


### PR DESCRIPTION
Example of setting MAX_CONNECTIONS constant to 2:
![Screenshot_20250507_215208](https://github.com/user-attachments/assets/184e80b3-0c73-4d84-8e71-e4f7e5336af7)
